### PR TITLE
fix: タスク追加後にTodoリストが更新されない問題を修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 .externalNativeBuild
 .cxx
 local.properties
+vcs.xml

--- a/app/src/main/java/com/example/todoapp/data/repository/TodoRepository.kt
+++ b/app/src/main/java/com/example/todoapp/data/repository/TodoRepository.kt
@@ -2,7 +2,6 @@ package com.example.todoapp.data.repository
 
 import com.example.todoapp.data.model.Todo
 import com.example.todoapp.data.network.ApiClient
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -26,7 +25,6 @@ class TodoRepository {
         try {
             val newTodo = Todo(title = title, completed = false)
             api.addTodo(newTodo)
-            fetchTodos() // 追加後に再取得
         } catch (e: Exception) {
             e.printStackTrace()
         }

--- a/app/src/main/java/com/example/todoapp/viewmodel/TodoViewModel.kt
+++ b/app/src/main/java/com/example/todoapp/viewmodel/TodoViewModel.kt
@@ -23,6 +23,7 @@ class TodoViewModel : ViewModel() {
     fun addTodo(title: String) {
         viewModelScope.launch {
             repository.addTodo(title)
+            repository.fetchTodos()
         }
     }
 }


### PR DESCRIPTION
## 概要
タスクを追加した後に、Todoリストに即時反映されないバグを修正しました。

## 修正内容
- `viewModel.addTodo()` の内部で `fetchTodos()` を呼ぶように修正

## 確認方法
1. Todoを追加する
2. 追加直後にリスト画面に戻り、タスクが反映されていることを確認